### PR TITLE
More resilient find image for journalctl [ch3318]

### DIFF
--- a/pkg/plugins/docker/util/this-container.go
+++ b/pkg/plugins/docker/util/this-container.go
@@ -2,25 +2,38 @@ package util
 
 import (
 	"context"
-	"os"
 	"strings"
+	"sync"
 
 	dockertypes "github.com/docker/docker/api/types"
 	docker "github.com/docker/docker/client"
 	"github.com/pkg/errors"
 )
 
+var (
+	thisContainer    *dockertypes.Container
+	thisContainerMtx sync.Mutex
+)
+
+// find a running container with image containing "support-bundle"
 func ThisContainer(ctx context.Context, client *docker.Client) (*dockertypes.Container, error) {
-	thisCmd := strings.Join(os.Args, " ")
+	thisContainerMtx.Lock()
+	defer thisContainerMtx.Unlock()
+
+	if thisContainer != nil {
+		return thisContainer, nil
+	}
 
 	containers, err := client.ContainerList(ctx, dockertypes.ContainerListOptions{})
 	if err != nil {
 		return nil, err
 	}
 	for _, c := range containers {
-		if c.Command == thisCmd {
-			return &c, nil
+		if strings.Contains(c.Image, "support-bundle") {
+			thisContainer = &c
+			return thisContainer, nil
 		}
 	}
+
 	return nil, errors.New("not found")
 }


### PR DESCRIPTION
Iterate over running containers and find one whose image contains
"support-bundle". The pervious method of comparing process command to container command was unreliable.