### PR TITLE
Don't include output_dir if empty

### DIFF
--- a/pkg/types/spec.go
+++ b/pkg/types/spec.go
@@ -38,7 +38,7 @@ type UploadOptions struct {
 type SpecShared struct {
 	// Description describes this spec field
 	Description    string `json:"description,omitempty"`
-	OutputDir      string `json:"output_dir"`
+	OutputDir      string `json:"output_dir,omitempty"`
 	TimeoutSeconds int    `json:"timeout_seconds,omitempty"`
 	Scrub          *Scrub `json:"scrub,omitempty"`
 	Meta           *Meta  `json:"meta,omitempty"`


### PR DESCRIPTION
This avoids output like this:
    "spec": {
      "output_dir": "",
      "os.read-file": {
        "output_dir": "default/proc",
        "filepath": "/proc/meminfo"
      }
    }