### PR TITLE
On tagged releases, release docker image publicly

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,5 +37,14 @@ dockers:
     tag_templates:
     - "{{ .Tag }}"
     - latest
+  - image: replicated/support-bundle
+    dockerfile: build/Dockerfile-release
+    goos: linux
+    goarch: amd64
+    binary: support-bundle
+    tag_templates:
+      - "alpha"
+      - "stable"
+      - "{{ .Tag }}"
 snapshot:
   name_template: SNAPSHOT-{{ .Commit }}


### PR DESCRIPTION
https://github.com/goreleaser/goreleaser/issues/673 has been fixed so we can undo https://github.com/replicatedcom/support-bundle/pull/141