### PR TITLE
Goreleaser docker.latest deprecated

### DIFF
--- a/.goreleaser.unstable.yml
+++ b/.goreleaser.unstable.yml
@@ -54,7 +54,6 @@ dockers:
       - "unstable"
   - image: replicated/support-bundle
     dockerfile: deploy/Dockerfile-collect
-    latest: false
     goos: linux
     goarch: amd64
     binary: support-bundle


### PR DESCRIPTION
https://goreleaser.com/deprecations/#docker-latest