### PR TITLE
add working directory to support bundle base

### DIFF
--- a/deploy/Dockerfile-base
+++ b/deploy/Dockerfile-base
@@ -16,3 +16,4 @@ RUN export CLOUD_SDK_REPO="cloud-sdk-stretch" && \
   curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
   DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install google-cloud-sdk -y --no-install-recommends && \
   rm -rf /var/lib/apt/lists/*
+WORKDIR /out


### PR DESCRIPTION
This will allow us to shorten the support bundle `docker run` command by ommitting `--workdir /out`