### PR TITLE
Audit Log, not Retraced

### DIFF
--- a/hack/docs/mutations.json
+++ b/hack/docs/mutations.json
@@ -4505,7 +4505,7 @@
 
     },
     "merge": {
-      "description": "Collect Audit Log events from a running Retraced instance",
+      "description": "Collect Audit Log events from a running Audit Log instance",
       "examples": [
         {
           "output_dir": "/audit/events",

--- a/hack/docs/schema.json
+++ b/hack/docs/schema.json
@@ -5788,7 +5788,7 @@
                 "type": "string"
               },
               "retraced.events": {
-                "description": "Collect Audit Log events from a running Retraced instance",
+                "description": "Collect Audit Log events from a running Audit Log instance",
                 "examples": [
                   {
                     "output_dir": "/audit/events",


### PR DESCRIPTION
Due to changes @fshot pointed out on replicatedhq/help-center#750