### PR TITLE
use bufio.Reader, not bufio.Scanner, to read lines to scrub

### DIFF
--- a/pkg/collect/plans/structured_source.go
+++ b/pkg/collect/plans/structured_source.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/replicatedcom/support-bundle/pkg/collect/types"
 )
 
@@ -65,7 +67,7 @@ func (task *StructuredSource) Exec(ctx context.Context, rootDir string) []*types
 			}
 			data, err := json.Marshal(structured)
 			if err != nil {
-				return nil, err
+				return nil, errors.Wrap(err, "json.Marshal")
 			}
 			return map[string]io.Reader{"": bytes.NewReader(data)}, nil
 		}

--- a/pkg/collect/plans/util_test.go
+++ b/pkg/collect/plans/util_test.go
@@ -2,7 +2,11 @@ package plans
 
 import (
 	"bytes"
+	"math/rand"
+	"regexp"
 	"testing"
+
+	"github.com/replicatedcom/support-bundle/pkg/collect/types"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -73,4 +77,64 @@ end
 			assert.Equal(t, tt.expected, out.String())
 		})
 	}
+}
+
+func Test_filterLongStream(t *testing.T) {
+	tests := []struct {
+		name    string
+		regex   string
+		replace string
+		n       int
+		charset string
+	}{
+		{
+			name:    "1,000",
+			regex:   "abc",
+			replace: "xyz",
+			n:       1000,
+			charset: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
+		},
+		{
+			name:    "1,000,000",
+			regex:   "abc",
+			replace: "xyz",
+			n:       1000 * 1000,
+			charset: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
+		},
+		{
+			name:    "10,000,000",
+			regex:   "abc",
+			replace: "xyz",
+			n:       1000 * 1000 * 10,
+			charset: "abcdefghijklmnopqrstuvwxyz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+			scrubber, err := RawScrubber(&types.Scrub{Regex: tt.regex, Replace: tt.replace})
+			req.NoError(err)
+
+			in := bytes.NewBuffer(randStringBytes(tt.n, tt.charset))
+			out := bytes.NewBuffer(nil)
+			out.Grow(tt.n)
+
+			err = filterStreams(in, out, scrubber)
+			req.NoError(err)
+
+			outBytes := out.Bytes()
+			inRegex := regexp.MustCompile(tt.regex)
+			req.Falsef(inRegex.Match(outBytes), "input regex %q must not match the output string %q\n", tt.regex, outBytes)
+		})
+	}
+
+}
+
+func randStringBytes(n int, letterBytes string) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return b
 }


### PR DESCRIPTION
otherwise large binaries can cause "bufio.Scanner: token too long" errors