### PR TITLE
Skip docker.container-run test.

### DIFF
--- a/e2e/collect/docker/docker_container_run_test.go
+++ b/e2e/collect/docker/docker_container_run_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/replicatedcom/support-bundle/e2e/collect/ginkgo"
 )
 
-var _ = Describe("docker.container-run", func() {
+var _ = XDescribe("docker.container-run", func() {
 
 	BeforeEach(EnterNewTempDir)
 	AfterEach(LogResultsFromBundle)


### PR DESCRIPTION
It uses the same docker util that is breaking the skipped tests for
os.read-file in docker.