### PR TITLE
Upgrade all deps in base image

### DIFF
--- a/deploy/Dockerfile-base
+++ b/deploy/Dockerfile-base
@@ -1,6 +1,6 @@
 FROM debian:bookworm-slim
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update -y && apt-get install --no-install-recommends -y \
+RUN apt-get update -y && apt-get upgrade -y && apt-get install --no-install-recommends -y \
     ca-certificates \
     curl \
     iproute2 \


### PR DESCRIPTION
libc fixes are not yet in the base image.  The upgrade command increases image size from 120MB to 137MB

```
$ make scan-base
...
[0003]  INFO found 136 vulnerabilities for 150 packages
[0003] DEBUG   ├── fixed: 0
[0003] DEBUG   └── matched: 136
[0003] DEBUG       ├── unknown severity: 4
[0003] DEBUG       ├── negligible: 97
[0003] DEBUG       ├── low: 7
[0003] DEBUG       ├── medium: 23
[0003] DEBUG       ├── high: 4
[0003] DEBUG       └── critical: 1
[0003]  INFO ignoring 136 matches due to user-provided ignore rules
No vulnerabilities found
```